### PR TITLE
Help via help i 2

### DIFF
--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -450,6 +450,7 @@ loop = do
           DebugNumberedArgsI{} -> wat
           DebugBranchHistoryI{} -> wat
           DebugTypecheckedUnisonFileI{} -> wat
+          HelpI{} -> wat
           HelpTopicI{} -> wat
           QuitI{} -> wat
           DeprecateTermI{} -> undefined
@@ -1689,6 +1690,7 @@ loop = do
         doRemoveReplacement from patchPath False
       ShowDefinitionByPrefixI {} -> notImplemented
       UpdateBuiltinsI -> notImplemented
+      HelpI maybeName -> respond $ ShowHelp maybeName
       HelpTopicI maybeTopic -> respond $ ShowHelpTopic maybeTopic
       QuitI -> MaybeT $ pure Nothing
      where

--- a/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/HandleInput.hs
@@ -1690,7 +1690,7 @@ loop = do
         doRemoveReplacement from patchPath False
       ShowDefinitionByPrefixI {} -> notImplemented
       UpdateBuiltinsI -> notImplemented
-      HelpI maybeName -> respond $ ShowHelp maybeName
+      HelpI maybeName isFailure -> respond $ ShowHelp maybeName isFailure
       HelpTopicI maybeTopic -> respond $ ShowHelpTopic maybeTopic
       QuitI -> MaybeT $ pure Nothing
      where

--- a/parser-typechecker/src/Unison/Codebase/Editor/Help.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Help.hs
@@ -1,6 +1,10 @@
 {-# LANGUAGE OverloadedStrings   #-}
 
-module Unison.Codebase.Editor.Help where
+module Unison.Codebase.Editor.Help
+  ( help
+  , helpFor
+  )
+where
 
 import           Unison.Prelude
 

--- a/parser-typechecker/src/Unison/Codebase/Editor/Help.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Help.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE OverloadedStrings   #-}
+
+module Unison.Codebase.Editor.Help where
+
+import Unison.Prelude
+
+import           Data.List (intercalate, find, sortOn)
+import qualified Unison.CommandLine.InputPattern as I
+import qualified Unison.CommandLine.InputPatterns as IP
+import qualified Unison.Util.ColorText as CT
+import qualified Unison.Util.Pretty as P
+import           Unison.Util.Monoid (intercalateMap)
+
+helpAll :: P.Pretty CT.ColorText
+helpAll = intercalateMap "\n\n" showPatternHelp (sortOn I.patternName IP.validInputs)
+
+findByName :: String -> Maybe I.InputPattern
+findByName c = find (\pattern -> (I.patternName pattern) == c) IP.validInputs
+
+showPatternHelp :: I.InputPattern -> P.Pretty CT.ColorText
+showPatternHelp i = P.lines [
+  P.bold (fromString $ I.patternName i) <> fromString
+    (if not . null $ I.aliases i
+     then " (or " <> intercalate ", " (I.aliases i) <> ")"
+     else ""),
+  P.wrap $ I.help i ]

--- a/parser-typechecker/src/Unison/Codebase/Editor/Help.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Help.hs
@@ -11,8 +11,13 @@ import qualified Unison.Util.ColorText as CT
 import qualified Unison.Util.Pretty as P
 import           Unison.Util.Monoid (intercalateMap)
 
-helpAll :: P.Pretty CT.ColorText
-helpAll = intercalateMap "\n\n" showPatternHelp (sortOn I.patternName IP.validInputs)
+help :: P.Pretty CT.ColorText
+help = intercalateMap "\n\n" showPatternHelp (sortOn I.patternName IP.validInputs)
+
+helpFor :: String -> P.Pretty CT.ColorText
+helpFor command = case findByName command of
+  Just pat -> showPatternHelp pat
+  Nothing -> help
 
 findByName :: String -> Maybe I.InputPattern
 findByName c = find (\pattern -> (I.patternName pattern) == c) IP.validInputs

--- a/parser-typechecker/src/Unison/Codebase/Editor/Help.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Help.hs
@@ -2,30 +2,38 @@
 
 module Unison.Codebase.Editor.Help where
 
-import Unison.Prelude
+import           Unison.Prelude
 
-import           Data.List (intercalate, find, sortOn)
-import qualified Unison.CommandLine.InputPattern as I
-import qualified Unison.CommandLine.InputPatterns as IP
-import qualified Unison.Util.ColorText as CT
-import qualified Unison.Util.Pretty as P
-import           Unison.Util.Monoid (intercalateMap)
+import           Data.List                      ( intercalate
+                                                , find
+                                                , sortOn
+                                                )
+import qualified Unison.CommandLine.InputPattern
+                                               as I
+import qualified Unison.CommandLine.InputPatterns
+                                               as IP
+import qualified Unison.Util.ColorText         as CT
+import qualified Unison.Util.Pretty            as P
+import           Unison.Util.Monoid             ( intercalateMap )
 
 help :: P.Pretty CT.ColorText
-help = intercalateMap "\n\n" showPatternHelp (sortOn I.patternName IP.validInputs)
+help =
+  intercalateMap "\n\n" showPatternHelp (sortOn I.patternName IP.validInputs)
 
 helpFor :: String -> P.Pretty CT.ColorText
 helpFor command = case findByName command of
   Just pat -> showPatternHelp pat
-  Nothing -> help
+  Nothing  -> help
 
 findByName :: String -> Maybe I.InputPattern
-findByName c = find (\pattern -> (I.patternName pattern) == c) IP.validInputs
+findByName c = find (\p -> c == I.patternName p) IP.validInputs
 
 showPatternHelp :: I.InputPattern -> P.Pretty CT.ColorText
-showPatternHelp i = P.lines [
-  P.bold (fromString $ I.patternName i) <> fromString
+showPatternHelp i = P.lines
+  [ P.bold (fromString $ I.patternName i) <> fromString
     (if not . null $ I.aliases i
-     then " (or " <> intercalate ", " (I.aliases i) <> ")"
-     else ""),
-  P.wrap $ I.help i ]
+      then " (or " <> intercalate ", " (I.aliases i) <> ")"
+      else ""
+    )
+  , P.wrap $ I.help i
+  ]

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -133,6 +133,7 @@ data Input
   | DebugBranchHistoryI
   | DebugTypecheckedUnisonFileI
   | HelpTopicI (Maybe HelpTopic)
+  | HelpI (Maybe String)
   | QuitI
   deriving (Eq, Show)
 

--- a/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Input.hs
@@ -133,7 +133,7 @@ data Input
   | DebugBranchHistoryI
   | DebugTypecheckedUnisonFileI
   | HelpTopicI (Maybe HelpTopic)
-  | HelpI (Maybe String)
+  | HelpI (Maybe String) Bool
   | QuitI
   deriving (Eq, Show)
 

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -202,6 +202,7 @@ data Output v
   | DumpBitBooster Branch.Hash (Map Branch.Hash [Branch.Hash])
   | DumpUnisonFileHashes Int [(Name, Reference.Id)] [(Name, Reference.Id)] [(Name, Reference.Id)]
   | BadName String
+  | ShowHelp (Maybe String)
   | ShowHelpTopic (Maybe HT.HelpTopic)
   deriving (Show)
 
@@ -337,6 +338,7 @@ isFailure o = case o of
   ListDependencies{} -> False
   ListDependents{} -> False
   DumpUnisonFileHashes _ x y z -> x == mempty && y == mempty && z == mempty
+  ShowHelp{} -> False
   ShowHelpTopic{} -> False
 
 isNumberedFailure :: NumberedOutput v -> Bool

--- a/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
+++ b/parser-typechecker/src/Unison/Codebase/Editor/Output.hs
@@ -202,7 +202,7 @@ data Output v
   | DumpBitBooster Branch.Hash (Map Branch.Hash [Branch.Hash])
   | DumpUnisonFileHashes Int [(Name, Reference.Id)] [(Name, Reference.Id)] [(Name, Reference.Id)]
   | BadName String
-  | ShowHelp (Maybe String)
+  | ShowHelp (Maybe String) Bool
   | ShowHelpTopic (Maybe HT.HelpTopic)
   deriving (Show)
 
@@ -338,7 +338,7 @@ isFailure o = case o of
   ListDependencies{} -> False
   ListDependents{} -> False
   DumpUnisonFileHashes _ x y z -> x == mempty && y == mempty && z == mempty
-  ShowHelp{} -> False
+  ShowHelp _ isFailure -> isFailure
   ShowHelpTopic{} -> False
 
 isNumberedFailure :: NumberedOutput v -> Bool

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -10,7 +10,7 @@ import Unison.Prelude
 
 import qualified Control.Lens.Cons as Cons
 import Data.Bifunctor (first, second)
-import Data.List (intercalate, sortOn, isPrefixOf)
+import Data.List (isPrefixOf)
 import Data.List.Extra (nubOrdOn)
 import qualified System.Console.Haskeline.Completion as Completion
 import System.Console.Haskeline.Completion (Completion(Completion))
@@ -41,15 +41,6 @@ import qualified Unison.Util.Pretty as P
 import qualified Unison.Util.Relation as R
 import qualified Unison.Codebase.Editor.UriParser as UriParser
 import Unison.Codebase.Editor.RemoteRepo (RemoteNamespace)
-
-showPatternHelp :: InputPattern -> P.Pretty CT.ColorText
-
-showPatternHelp i = P.lines [
-  P.bold (fromString $ I.patternName i) <> fromString
-    (if not . null $ I.aliases i
-     then " (or " <> intercalate ", " (I.aliases i) <> ")"
-     else ""),
-  P.wrap $ I.help i ]
 
 patternName :: InputPattern -> P.Pretty P.ColorText
 patternName = fromString . I.patternName
@@ -139,8 +130,8 @@ load = InputPattern
   (\case
     [] -> pure $ Input.LoadI Nothing
     [file] -> pure $ Input.LoadI . Just $ file
-    _ -> Left (I.help load))
-
+    _ -> pure $ Input.HelpI (Just $ I.patternName load) True
+  )
 
 add :: InputPattern
 add =
@@ -281,7 +272,7 @@ display = InputPattern
   "`display foo` prints a rendered version of the term `foo`."
   (\case
     [s] -> Input.DisplayI Input.ConsoleLocation <$> parseHashQualifiedName s
-    _   -> Left (I.help display)
+    _ -> pure $ Input.HelpI (Just $ I.patternName display) True
   )
 
 
@@ -297,7 +288,7 @@ displayTo = InputPattern
   (\case
     [file, s] ->
       Input.DisplayI (Input.FileLocation file) <$> parseHashQualifiedName s
-    _ -> Left (I.help displayTo)
+    _ -> pure $ Input.HelpI (Just $ I.patternName displayTo) True
   )
 
 docs :: InputPattern
@@ -305,7 +296,8 @@ docs = InputPattern "docs" [] [(Required, definitionQueryArg)]
       "`docs foo` shows documentation for the definition `foo`."
       (\case
         [s] -> first fromString $ Input.DocsI <$> Path.parseHQSplit' s
-        _ -> Left (I.help docs))
+        _ -> pure $ Input.HelpI (Just $ I.patternName docs) True
+    )
 
 undo :: InputPattern
 undo = InputPattern "undo" [] []
@@ -357,7 +349,7 @@ findShallow = InputPattern
     [path] -> first fromString $ do
       p <- Path.parsePath' path
       pure $ Input.FindShallowI p
-    _ -> Left (I.help findShallow)
+    _ -> pure $ Input.HelpI (Just $ I.patternName findShallow) True
   )
 
 findVerbose :: InputPattern
@@ -546,7 +538,7 @@ aliasMany = InputPattern "alias.many" ["copy"]
       sourceDefinitions <- traverse Path.parseHQSplit srcs
       destNamespace <- Path.parsePath' dest
       pure $ Input.AliasManyI sourceDefinitions destNamespace
-    _ -> Left (I.help aliasMany)
+    _ -> pure $ Input.HelpI (Just $ I.patternName aliasMany) True
   )
 
 
@@ -561,7 +553,7 @@ cd = InputPattern "namespace" ["cd", "j"] [(Required, pathArg)]
       [p] -> first fromString $ do
         p <- Path.parsePath' p
         pure . Input.SwitchBranchI $ p
-      _ -> Left (I.help cd)
+      _ -> pure $ Input.HelpI (Just $ I.patternName cd) True
     )
 
 back :: InputPattern
@@ -572,7 +564,7 @@ back = InputPattern "back" ["popd"] []
       ])
     (\case
       [] -> pure Input.PopBranchI
-      _ -> Left (I.help cd)
+      _ -> pure $ Input.HelpI (Just $ I.patternName cd) True
     )
 
 deleteBranch :: InputPattern
@@ -584,7 +576,7 @@ deleteBranch = InputPattern "delete.namespace" [] [(Required, pathArg)]
         [p] -> first fromString $ do
           p <- Path.parseSplit' Path.wordyNameSegment p
           pure . Input.DeleteBranchI $ Just p
-        _ -> Left (I.help deleteBranch)
+        _ -> pure $ Input.HelpI (Just $ I.patternName deleteBranch) True
       )
 
 deletePatch :: InputPattern
@@ -594,7 +586,7 @@ deletePatch = InputPattern "delete.patch" [] [(Required, patchArg)]
         [p] -> first fromString $ do
           p <- Path.parseSplit' Path.wordyNameSegment p
           pure . Input.DeletePatchI $ p
-        _ -> Left (I.help deletePatch)
+        _ -> pure $ Input.HelpI (Just $ I.patternName deletePatch) True
       )
 
 movePatch :: String -> String -> Either (P.Pretty CT.ColorText) Input
@@ -610,7 +602,7 @@ copyPatch = InputPattern "copy.patch"
    "`copy.patch foo bar` copies the patch `bar` to `foo`."
     (\case
       [src, dest] -> movePatch src dest
-      _ -> Left (I.help copyPatch)
+      _ -> pure $ Input.HelpI (Just $ I.patternName copyPatch) True
     )
 
 renamePatch :: InputPattern
@@ -620,7 +612,7 @@ renamePatch = InputPattern "move.patch"
    "`move.patch foo bar` renames the patch `bar` to `foo`."
     (\case
       [src, dest] -> movePatch src dest
-      _ -> Left (I.help renamePatch)
+      _ -> pure $ Input.HelpI (Just $ I.patternName renamePatch) True
     )
 
 renameBranch :: InputPattern
@@ -636,7 +628,7 @@ renameBranch = InputPattern "move.namespace"
         src <- Path.parseSplit' Path.wordyNameSegment src
         dest <- Path.parseSplit' Path.wordyNameSegment dest
         pure $ Input.MoveBranchI (Just src) dest
-      _ -> Left (I.help renameBranch)
+      _ -> pure $ Input.HelpI (Just $ I.patternName renameBranch) True
     )
 
 history :: InputPattern
@@ -654,7 +646,7 @@ history = InputPattern "history" []
         p <- Input.parseBranchId src
         pure $ Input.HistoryI (Just 10) (Just 10) p
       [] -> pure $ Input.HistoryI (Just 10) (Just 10) (Right Path.currentPath)
-      _ -> Left (I.help history)
+      _ -> pure $ Input.HelpI (Just $ I.patternName history) True
     )
 
 forkLocal :: InputPattern
@@ -666,7 +658,7 @@ forkLocal = InputPattern "fork" ["copy.namespace"] [(Required, pathArg)
         src <- Input.parseBranchId src
         dest <- Path.parsePath' dest
         pure $ Input.ForkLocalBranchI src dest
-      _ -> Left (I.help forkLocal)
+      _ -> pure $ Input.HelpI (Just $ I.patternName forkLocal) True
     )
 
 resetRoot :: InputPattern
@@ -681,7 +673,8 @@ resetRoot = InputPattern "reset-root" [] [(Required, pathArg)]
     [src] -> first fromString $ do
      src <- Input.parseBranchId src
      pure $ Input.ResetRootI src
-    _ -> Left (I.help resetRoot))
+    _ -> pure $ Input.HelpI (Just $ I.patternName resetRoot) True
+  )
 
 pull :: InputPattern
 pull = InputPattern
@@ -725,7 +718,7 @@ pull = InputPattern
               (P.parse UriParser.repoPath "url" (Text.pack url))
       p <- first fromString $ Path.parsePath' path
       pure $ Input.PullRemoteBranchI (Just ns) p
-    _ -> Left (I.help pull)
+    _ -> pure $ Input.HelpI (Just $ I.patternName pull) True
   )
 
 push :: InputPattern
@@ -768,6 +761,7 @@ push = InputPattern
       p <- case rest of
         [] -> Right Path.relativeEmpty'
         [path] -> first fromString $ Path.parsePath' path
+        -- todo: change to use HelpI
         _ -> Left (I.help push)
       Right $ Input.PushRemoteBranchI (Just (repo, path)) p
   )
@@ -789,7 +783,7 @@ createPullRequest = InputPattern "pull-request.create" ["pr.create"]
       baseRepo <- parseUri "baseRepo" baseUrl
       headRepo <- parseUri "headRepo" headUrl
       pure $ Input.CreatePullRequestI baseRepo headRepo
-    _ -> Left (I.help createPullRequest)
+    _ -> pure $ Input.HelpI (Just $ I.patternName createPullRequest) True
   )
 
 loadPullRequest :: InputPattern
@@ -814,7 +808,7 @@ loadPullRequest = InputPattern "pull-request.load" ["pr.load"]
       headRepo <- parseUri "topicRepo" headUrl
       destPath <- Path.parsePath' dest
       pure $ Input.LoadPullRequestI baseRepo headRepo destPath
-    _ -> Left (I.help loadPullRequest)
+    _ -> pure $ Input.HelpI (Just $ I.patternName loadPullRequest) True
   )
 parseUri :: IsString b => String -> String -> Either b RemoteNamespace
 parseUri label input =
@@ -835,7 +829,7 @@ mergeLocal = InputPattern "merge" [] [(Required, pathArg)
         src <- Path.parsePath' src
         dest <- Path.parsePath' dest
         pure $ Input.MergeLocalBranchI src dest
-      _ -> Left (I.help mergeLocal)
+      _ -> pure $ Input.HelpI (Just $ I.patternName mergeLocal) True
  )
 
 diffNamespace :: InputPattern
@@ -855,7 +849,7 @@ diffNamespace = InputPattern
       before <- Path.parsePath' before
       after <- Path.parsePath' after
       pure $ Input.DiffNamespaceI before after
-    _ -> Left $ I.help diffNamespace
+    _ -> pure $ Input.HelpI (Just $ I.patternName diffNamespace) True
   )
 
 previewMergeLocal :: InputPattern
@@ -880,7 +874,7 @@ previewMergeLocal = InputPattern
       src  <- Path.parsePath' src
       dest <- Path.parsePath' dest
       pure $ Input.PreviewMergeLocalBranchI src dest
-    _ -> Left (I.help previewMergeLocal)
+    _ -> pure $ Input.HelpI (Just $ I.patternName previewMergeLocal) True
   )
 
 replaceEdit
@@ -921,7 +915,7 @@ replaceEdit f s = self
         sourcehq <- parseHashQualifiedName source
         targethq <- parseHashQualifiedName target
         pure $ f sourcehq targethq patch
-      _ -> Left $ I.help self
+      _ -> pure $ Input.HelpI (Just $ I.patternName self) True
     )
 
 replaceType :: InputPattern
@@ -975,12 +969,11 @@ help = InputPattern
     "help" ["?"] [(Optional, commandNameArg)]
     "`help` shows general help and `help <cmd>` shows help for one command."
     (\case
-      [] -> Left $ intercalateMap "\n\n" showPatternHelp
-        (sortOn I.patternName validInputs)
+      [] -> Right $ Input.HelpI Nothing False
       [isHelp -> Right ht] -> Right ht
       [cmd] -> case Map.lookup cmd commandsByName of
         Nothing  -> Left . warn $ "I don't know of that command. Try `help`."
-        Just pat -> Left $ showPatternHelp pat
+        Just _ -> Right $ Input.HelpI (Just cmd) False
       _ -> Left $ warn "Use `help <cmd>` or `help`.")
     where
       commandsByName = Map.fromList [
@@ -1034,7 +1027,7 @@ link = InputPattern
         Just hq -> pure hq
       defs <- traverse Path.parseHQSplit' defs
       Right $ Input.LinkI md defs
-    _ -> Left (I.help link)
+    _ -> pure $ Input.HelpI (Just $ I.patternName link) True
   )
 
 links :: InputPattern
@@ -1052,7 +1045,7 @@ links = InputPattern
             [] -> Nothing
             _  -> Just $ unwords rest
        in Right $ Input.LinksI src ty
-    _ -> Left (I.help links)
+    _ -> pure $ Input.HelpI (Just $ I.patternName links) True
   )
 
 unlink :: InputPattern
@@ -1073,7 +1066,7 @@ unlink = InputPattern
         Just hq -> pure hq
       defs <- traverse Path.parseHQSplit' defs
       Right $ Input.UnlinkI md defs
-    _ -> Left (I.help unlink)
+    _ -> pure $ Input.HelpI (Just $ I.patternName unlink) True
   )
 
 names :: InputPattern
@@ -1085,7 +1078,7 @@ names = InputPattern "names" []
       Just hq -> Right $ Input.NamesI hq
       Nothing -> Left $ "I was looking for one of these forms: "
                        <> P.blue "foo .foo.bar foo#abc #abcde .foo.bar#asdf"
-    _ -> Left (I.help names)
+    _ -> pure $ Input.HelpI (Just $ I.patternName names) True
   )
 
 dependents, dependencies :: InputPattern
@@ -1093,12 +1086,14 @@ dependents = InputPattern "dependents" [] []
   "List the dependents of the specified definition."
   (\case
     [thing] -> fmap Input.ListDependentsI $ parseHashQualifiedName thing
-    _ -> Left (I.help dependents))
+    _ -> pure $ Input.HelpI (Just $ I.patternName dependents) True
+  )
 dependencies = InputPattern "dependencies" [] []
   "List the dependencies of the specified definition."
   (\case
     [thing] -> fmap Input.ListDependenciesI $ parseHashQualifiedName thing
-    _ -> Left (I.help dependencies))
+    _ -> pure $ Input.HelpI (Just $ I.patternName dependencies) True
+  )
 
 debugNumberedArgs :: InputPattern
 debugNumberedArgs = InputPattern "debug.numberedArgs" [] []
@@ -1135,7 +1130,7 @@ execute = InputPattern
   )
   (\case
     [w] -> pure . Input.ExecuteI $ w
-    _   -> Left $ showPatternHelp execute
+    _   -> pure $ Input.HelpI (Just $ I.patternName execute) True
   )
 
 createAuthor :: InputPattern
@@ -1154,7 +1149,7 @@ createAuthor = InputPattern "create.author" []
               quoted@('"':_) -> (init . tail) quoted
               bare -> bare
         pure $ Input.CreateAuthorI symbol author
-      _   -> Left $ showPatternHelp createAuthor
+      _   -> pure $ Input.HelpI (Just $ I.patternName createAuthor) True
     )
 validInputs :: [InputPattern]
 validInputs =

--- a/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
+++ b/parser-typechecker/src/Unison/CommandLine/InputPatterns.hs
@@ -758,12 +758,11 @@ push = InputPattern
         (P.parse UriParser.repoPath "url" (Text.pack url))
       when (isJust sbh)
         $ Left "Can't push to a particular remote namespace hash."
-      p <- case rest of
-        [] -> Right Path.relativeEmpty'
-        [path] -> first fromString $ Path.parsePath' path
-        -- todo: change to use HelpI
-        _ -> Left (I.help push)
-      Right $ Input.PushRemoteBranchI (Just (repo, path)) p
+      case rest of
+        [] -> Right $ Input.PushRemoteBranchI (Just (repo, path)) Path.relativeEmpty'
+        [path'] -> first fromString $ Path.parsePath' path' >>= 
+          Right . Input.PushRemoteBranchI (Just (repo, path))
+        _ -> Right $ Input.HelpI (Just $ I.patternName push) True
   )
 
 createPullRequest :: InputPattern

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -1022,8 +1022,8 @@ notifyUser dir o = case o of
         prettyHashQualified' (HQ'.take hqLength . HQ'.fromNamedReference n $ Reference.DerivedId r))
 
   ShowHelp maybeCommandName _ -> case maybeCommandName of
-    Just _  -> pure $ P.string ""
-    Nothing -> pure $ H.helpAll
+    Just cmd -> pure $ H.helpFor cmd
+    Nothing -> pure $ H.help
 
   ShowHelpTopic maybeTopic -> case maybeTopic of
     Just helpTopic -> pure $ HT.toPretty helpTopic

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -13,6 +13,7 @@ module Unison.CommandLine.OutputMessages where
 
 import Unison.Prelude hiding (unlessM)
 
+import qualified Unison.Codebase.Editor.Help             as H
 import qualified Unison.Codebase.Editor.HelpTopics       as HT
 import           Unison.Codebase.Editor.Output
 import qualified Unison.Codebase.Editor.Output           as E
@@ -1022,7 +1023,7 @@ notifyUser dir o = case o of
 
   ShowHelp maybeCommandName _ -> case maybeCommandName of
     Just _  -> pure $ P.string ""
-    Nothing -> pure $ P.string ""
+    Nothing -> pure $ H.helpAll
 
   ShowHelpTopic maybeTopic -> case maybeTopic of
     Just helpTopic -> pure $ HT.toPretty helpTopic

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -1020,7 +1020,7 @@ notifyUser dir o = case o of
       (terms <&> \(n,r) ->
         prettyHashQualified' (HQ'.take hqLength . HQ'.fromNamedReference n $ Reference.DerivedId r))
 
-  ShowHelp maybeCommandName -> case maybeCommandName of
+  ShowHelp maybeCommandName _ -> case maybeCommandName of
     Just _  -> pure $ P.string ""
     Nothing -> pure $ P.string ""
 

--- a/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
+++ b/parser-typechecker/src/Unison/CommandLine/OutputMessages.hs
@@ -1020,6 +1020,10 @@ notifyUser dir o = case o of
       (terms <&> \(n,r) ->
         prettyHashQualified' (HQ'.take hqLength . HQ'.fromNamedReference n $ Reference.DerivedId r))
 
+  ShowHelp maybeCommandName -> case maybeCommandName of
+    Just _  -> pure $ P.string ""
+    Nothing -> pure $ P.string ""
+
   ShowHelpTopic maybeTopic -> case maybeTopic of
     Just helpTopic -> pure $ HT.toPretty helpTopic
     Nothing -> pure HT.knownTopics

--- a/parser-typechecker/unison-parser-typechecker.cabal
+++ b/parser-typechecker/unison-parser-typechecker.cabal
@@ -51,6 +51,7 @@ library
     Unison.Codebase.Editor.HandleInput
     Unison.Codebase.Editor.HandleCommand
     Unison.Codebase.Editor.Input
+    Unison.Codebase.Editor.Help
     Unison.Codebase.Editor.HelpTopics
     Unison.Codebase.Editor.Output
     Unison.Codebase.Editor.Output.BranchDiff

--- a/unison-src/transcripts/help.md
+++ b/unison-src/transcripts/help.md
@@ -20,61 +20,169 @@ These are treated as failures (for example: a user invokes wrong arguments, less
 
 ```ucm:error
 .> load 1 2 3
+```
+```ucm:error
 .> display
+```
+```ucm:error
 .> display 1 2 3
+```
+```ucm:error
 .> display.to
+```
+```ucm:error
 .> display.to 1 2 3
+```
+```ucm:error
 .> docs
+```
+```ucm:error
 .> docs 1 2
+```
+```ucm:error
 .> list
+```
+```ucm:error
 .> list 1 2
+```
+```ucm:error
 .> alias.many
+```
+```ucm:error
 .> cd
+```
+```ucm:error
 .> cd 1 2 3
+```
+```ucm:error
 .> back 1
+```
+```ucm:error
 .> delete.namespace 1 2 3
+```
+```ucm:error
 .> delete.patch 1 2
+```
+```ucm:error
 .> copy.patch 1 2 3
+```
+```ucm:error
 .> rename.patch 1 2 3
+```
+```ucm:error
 .> rename.namespace 1 2 3
+```
+```ucm:error
 .> history 1 2 3
+```
+```ucm:error
 .> fork
+```
+```ucm:error
 .> fork 1
+```
+```ucm:error
 .> fork 1 2 3
+```
+```ucm:error
 .> reset-root
+```
+```ucm:error
 .> reset-root 1 2
+```
+```ucm:error
 .> pull
+```
+```ucm:error
 .> pull 1 2 3
+```
+```ucm:error
 .> pull-request.create
+```
+```ucm:error
 .> pull-request.create 1 2 3
+```
+```ucm:error
 .> pull-request.load
+```
+```ucm:error
 .> pull-request.load 1
+```
+```ucm:error
 .> pull-request.load 1 2 3 4
+```
+```ucm:error
 .> merge
+```
+```ucm:error
 .> merge 1 2 3
+```
+```ucm:error
 .> diff.namespace
+```
+```ucm:error
 .> diff.namespace 1
+```
+```ucm:error
 .> diff.namespace 1 2 3
+```
+```ucm:error
 .> merge.preview
+```
+```ucm:error
 .> merge.preview 1 2 3
+```
+```ucm:error
 .> replace.type
+```
+```ucm:error
 .> replace.type 1 
+```
+```ucm:error
 .> replace.type 1 2
+```
+```ucm:error
 .> replace.term
+```
+```ucm:error
 .> replace.term 1
+```
+```ucm:error
 .> replace.term 1 2
+```
+```ucm:error
 .> link
+```
+```ucm:error
 .> links
+```
+```ucm:error
 .> unlink
+```
+```ucm:error
 .> names
+```
+```ucm:error
 .> names 1 2
+```
+```ucm:error
 .> dependents
+```
+```ucm:error
 .> dependents 1 2
+```
+```ucm:error
 .> dependencies
+```
+```ucm:error
 .> dependencies 1 2
+```
+```ucm:error
 .> run
+```
+```ucm:error
 .> run 1 2
+```
+```ucm:error
 .> create.author
 ```
-
-load cannot be tested as its output changes per invocation of the trancript

--- a/unison-src/transcripts/help.md
+++ b/unison-src/transcripts/help.md
@@ -10,4 +10,70 @@
 .> help filestatus
 .> help namespaces
 .> help messages.disallowedAbsolute
+.> help
+.> help push
+```
+
+### Tests output 'help your-command' due to broken invocation of a command
+
+These are treated as failures (for example: a user invokes wrong arguments, less or more)
+
+```ucm:error
+.> load
+.> load 1 2 3
+.> display
+.> display 1 2 3
+.> display.to
+.> display.to 1 2 3
+.> docs
+.> docs 1 2
+.> list
+.> list 1 2
+.> alias.many
+.> cd
+.> cd 1 2 3
+.> back 1
+.> delete.namespace 1 2 3
+.> delete.patch 1 2
+.> copy.patch 1 2 3
+.> rename.patch 1 2 3
+.> rename.namespace 1 2 3
+.> history 1 2 3
+.> fork
+.> fork 1
+.> fork 1 2 3
+.> reset-root
+.> reset-root 1 2
+.> pull
+.> pull 1 2 3
+.> pull-request.create
+.> pull-request.create 1 2 3
+.> pull-request.load
+.> pull-request.load 1
+.> pull-request.load 1 2 3 4
+.> merge
+.> merge 1 2 3
+.> diff.namespace
+.> diff.namespace 1
+.> diff.namespace 1 2 3
+.> merge.preview
+.> merge.preview 1 2 3
+.> replace.type
+.> replace.type 1 
+.> replace.type 1 2
+.> replace.term
+.> replace.term 1
+.> replace.term 1 2
+.> link
+.> links
+.> unlink
+.> names
+.> names 1 2
+.> dependents
+.> dependents 1 2
+.> dependencies
+.> dependencies 1 2
+.> run
+.> run 1 2
+.> create.author
 ```

--- a/unison-src/transcripts/help.md
+++ b/unison-src/transcripts/help.md
@@ -19,7 +19,6 @@
 These are treated as failures (for example: a user invokes wrong arguments, less or more)
 
 ```ucm:error
-.> load
 .> load 1 2 3
 .> display
 .> display 1 2 3
@@ -77,3 +76,5 @@ These are treated as failures (for example: a user invokes wrong arguments, less
 .> run 1 2
 .> create.author
 ```
+
+load cannot be tested as its output changes per invocation of the trancript

--- a/unison-src/transcripts/help.md
+++ b/unison-src/transcripts/help.md
@@ -97,6 +97,9 @@ These are treated as failures (for example: a user invokes wrong arguments, less
 .> pull 1 2 3
 ```
 ```ucm:error
+.> push 1 2 3
+```
+```ucm:error
 .> pull-request.create
 ```
 ```ucm:error

--- a/unison-src/transcripts/help.output.md
+++ b/unison-src/transcripts/help.output.md
@@ -536,7 +536,22 @@
 
 .> help push
 
-  
+  push
+  The `push` command merges a local namespace into a remote
+  namespace.
+  `push remote local`  merges the contents of the local
+                       namespace `local` into the remote
+                       namespace `remote`.
+  `push remote`        publishes the current namespace into the
+                       remote namespace `remote`
+  `push`               publishes the current namespace into the
+                       remote namespace configured in
+                       `.unisonConfig` with the key `GitUrl.ns`
+                       where `ns` is the current namespace
+  where `remote` is a git repository, optionally followed by `:`
+  and an absolute remote path, such as:
+  `https://github.com/org/repo`
+  `https://github.com/org/repo:.some.remote.path`
 
 ```
 ### Tests output 'help your-command' due to broken invocation of a command
@@ -546,100 +561,212 @@ These are treated as failures (for example: a user invokes wrong arguments, less
 ```ucm
 .> load 1 2 3
 
-  
+  load
+  `load`                 parses, typechecks, and evaluates the
+                         most recent scratch file.
+  `load <scratch file>`  parses, typechecks, and evaluates the
+                         given scratch file.
 
+```
+```ucm
 .> display
 
-  
+  display
+  `display foo` prints a rendered version of the term `foo`.
 
+```
+```ucm
 .> display 1 2 3
 
-  
+  display
+  `display foo` prints a rendered version of the term `foo`.
 
+```
+```ucm
 .> display.to
 
-  
+  display.to
+  `display.to <filename> foo` prints a rendered version of the
+  term `foo` to the given file.
 
+```
+```ucm
 .> display.to 1 2 3
 
-  
+  display.to
+  `display.to <filename> foo` prints a rendered version of the
+  term `foo` to the given file.
 
+```
+```ucm
 .> docs
 
-  
+  docs
+  `docs foo` shows documentation for the definition `foo`.
 
+```
+```ucm
 .> docs 1 2
 
-  
+  docs
+  `docs foo` shows documentation for the definition `foo`.
 
+```
+```ucm
 .> list
 
   nothing to show
 
+```
+```ucm
 .> list 1 2
 
-  
+  list (or ls)
+  `list`       lists definitions and namespaces at the current
+               level of the current namespace.
+  `list foo`   lists the 'foo' namespace.
+  `list .foo`  lists the '.foo' namespace.
 
+```
+```ucm
 .> alias.many
 
-  
+  alias.many (or copy)
+  `alias.many <relative1> [relative2...] <namespace>` creates
+  aliases `relative1`, `relative2`, ... in the namespace
+  `namespace`.
+  `alias.many foo.foo bar.bar .quux` creates aliases
+  `.quux.foo.foo` and `.quux.bar.bar`.
 
+```
+```ucm
 .> cd
 
-  
+  namespace (or cd, j)
+  `namespace foo.bar`   descends into foo.bar from the current
+                        namespace.
+  `namespace .cat.dog`  sets the current namespace to the
+                        abolute namespace .cat.dog.
 
+```
+```ucm
 .> cd 1 2 3
 
-  
+  namespace (or cd, j)
+  `namespace foo.bar`   descends into foo.bar from the current
+                        namespace.
+  `namespace .cat.dog`  sets the current namespace to the
+                        abolute namespace .cat.dog.
 
+```
+```ucm
 .> back 1
 
-  
+  namespace (or cd, j)
+  `namespace foo.bar`   descends into foo.bar from the current
+                        namespace.
+  `namespace .cat.dog`  sets the current namespace to the
+                        abolute namespace .cat.dog.
 
+```
+```ucm
 .> delete.namespace 1 2 3
 
-  
+  delete.namespace
+  `delete.namespace <foo>` deletes the namespace `foo`
 
+```
+```ucm
 .> delete.patch 1 2
 
-  
+  delete.patch
+  `delete.patch <foo>` deletes the patch `foo`
 
+```
+```ucm
 .> copy.patch 1 2 3
 
-  
+  copy.patch
+  `copy.patch foo bar` copies the patch `bar` to `foo`.
 
+```
+```ucm
 .> rename.patch 1 2 3
 
-  
+  move.patch (or rename.patch)
+  `move.patch foo bar` renames the patch `bar` to `foo`.
 
+```
+```ucm
 .> rename.namespace 1 2 3
 
-  
+  move.namespace (or rename.namespace)
+  `move.namespace foo bar` renames the path `bar` to `foo`.
 
+```
+```ucm
 .> history 1 2 3
 
-  
+  history
+  `history`                     Shows the history of the current
+                                path.
+  `history .foo`                Shows history of the path .foo.
+  `history #9dndk3kbsk13nbpeu`  Shows the history of the
+                                namespace with the given hash.
+                                The full hash must be provided.
 
+```
+```ucm
 .> fork
 
-  
+  fork (or copy.namespace)
+  `fork src dest` creates the namespace `dest` as a copy of
+  `src`.
 
+```
+```ucm
 .> fork 1
 
-  
+  fork (or copy.namespace)
+  `fork src dest` creates the namespace `dest` as a copy of
+  `src`.
 
+```
+```ucm
 .> fork 1 2 3
 
-  
+  fork (or copy.namespace)
+  `fork src dest` creates the namespace `dest` as a copy of
+  `src`.
 
+```
+```ucm
 .> reset-root
 
-  
+  reset-root
+  `reset-root .foo`                Reset the root namespace
+                                   (along with its history) to
+                                   that of the `.foo` namespace.
+  `reset-root #9dndk3kbsk13nbpeu`  Reset the root namespace
+                                   (along with its history) to
+                                   that of the namespace with
+                                   hash `#9dndk3kbsk13nbpeu`.
 
+```
+```ucm
 .> reset-root 1 2
 
-  
+  reset-root
+  `reset-root .foo`                Reset the root namespace
+                                   (along with its history) to
+                                   that of the `.foo` namespace.
+  `reset-root #9dndk3kbsk13nbpeu`  Reset the root namespace
+                                   (along with its history) to
+                                   that of the namespace with
+                                   hash `#9dndk3kbsk13nbpeu`.
 
+```
+```ucm
 .> pull
 
   ❗️
@@ -648,66 +775,170 @@ These are treated as failures (for example: a user invokes wrong arguments, less
   current namespace = <some-git-url>' to .unisonConfig. Type
   `help pull ` for more information.
 
+```
+```ucm
 .> pull 1 2 3
 
-  
+  pull
+  The `pull` command merges a remote namespace into a local
+  namespace.
+  `pull remote local`  merges the remote namespace `remote` into
+                       the local namespace `local`.
+  `pull remote`        merges the remote namespace `remote` into
+                       the current namespace
+  `pull`               merges the remote namespace configured in
+                       `.unisonConfig` with the key `GitUrl.ns`
+                       where `ns` is the current namespace, into
+                       the current namespace
+  where `remote` is a git repository, optionally followed by `:`
+  and an absolute remote path, such as:
+  `https://github.com/org/repo`
+  `https://github.com/org/repo:.some.remote.path`
 
+```
+```ucm
 .> pull-request.create
 
+  pull-request.create (or pr.create)
+  `pull-request.create base head` will generate a request to
+  merge the remote repo `head` into the remote repo `base`.
   
+  example: pull-request.create https://github.com/unisonweb/base https://github.com/me/unison:.libs.pr.base
 
+```
+```ucm
 .> pull-request.create 1 2 3
 
+  pull-request.create (or pr.create)
+  `pull-request.create base head` will generate a request to
+  merge the remote repo `head` into the remote repo `base`.
   
+  example: pull-request.create https://github.com/unisonweb/base https://github.com/me/unison:.libs.pr.base
 
+```
+```ucm
 .> pull-request.load
 
-  
+  pull-request.load (or pr.load)
+  `pull-request.load base head` will load a pull request for
+  merging the remote repo `head` into the remote repo `base`,
+  staging each in the current namespace (so make yourself a
+  clean spot to work first).
+  `pull-request.load base head dest` will load a pull request
+  for merging the remote repo `head` into the remote repo
+  `base`, staging each in `dest`, which must be empty.
 
+```
+```ucm
 .> pull-request.load 1
 
-  
+  pull-request.load (or pr.load)
+  `pull-request.load base head` will load a pull request for
+  merging the remote repo `head` into the remote repo `base`,
+  staging each in the current namespace (so make yourself a
+  clean spot to work first).
+  `pull-request.load base head dest` will load a pull request
+  for merging the remote repo `head` into the remote repo
+  `base`, staging each in `dest`, which must be empty.
 
+```
+```ucm
 .> pull-request.load 1 2 3 4
 
-  
+  pull-request.load (or pr.load)
+  `pull-request.load base head` will load a pull request for
+  merging the remote repo `head` into the remote repo `base`,
+  staging each in the current namespace (so make yourself a
+  clean spot to work first).
+  `pull-request.load base head dest` will load a pull request
+  for merging the remote repo `head` into the remote repo
+  `base`, staging each in `dest`, which must be empty.
 
+```
+```ucm
 .> merge
 
-  
+  merge
+  `merge src`      merges `src` namespace into the current namespace
+  `merge src dest` merges `src` namespace into the `dest` namespace
 
+```
+```ucm
 .> merge 1 2 3
 
-  
+  merge
+  `merge src`      merges `src` namespace into the current namespace
+  `merge src dest` merges `src` namespace into the `dest` namespace
 
+```
+```ucm
 .> diff.namespace
 
-  
+  diff.namespace
+  `diff.namespace before after` shows how the namespace `after`
+                                differs from the namespace
+                                `before`
 
+```
+```ucm
 .> diff.namespace 1
 
-  
+  diff.namespace
+  `diff.namespace before after` shows how the namespace `after`
+                                differs from the namespace
+                                `before`
 
+```
+```ucm
 .> diff.namespace 1 2 3
 
-  
+  diff.namespace
+  `diff.namespace before after` shows how the namespace `after`
+                                differs from the namespace
+                                `before`
 
+```
+```ucm
 .> merge.preview
 
-  
+  merge.preview
+  `merge.preview src`      shows how the current namespace will change after a `merge src`.
+  `merge.preview src dest` shows how `dest` namespace will change after a `merge src dest`.
 
+```
+```ucm
 .> merge.preview 1 2 3
 
-  
+  merge.preview
+  `merge.preview src`      shows how the current namespace will change after a `merge src`.
+  `merge.preview src dest` shows how `dest` namespace will change after a `merge src dest`.
 
+```
+```ucm
 .> replace.type
 
-  
+  replace.type
+  `replace.type <from> <to> <patch>`  Replace the type <from> in
+                                      the given patch with the
+                                      type <to>.
+  `replace.type <from> <to>`          Replace the type <from>
+                                      with <to> in the default
+                                      patch.
 
+```
+```ucm
 .> replace.type 1 
 
-  
+  replace.type
+  `replace.type <from> <to> <patch>`  Replace the type <from> in
+                                      the given patch with the
+                                      type <to>.
+  `replace.type <from> <to>`          Replace the type <from>
+                                      with <to> in the default
+                                      patch.
 
+```
+```ucm
 .> replace.type 1 2
 
   ⚠️
@@ -718,14 +949,32 @@ These are treated as failures (for example: a user invokes wrong arguments, less
 
   1 is not a kind of name I understand.
 
+```
+```ucm
 .> replace.term
 
-  
+  replace.term
+  `replace.term <from> <to> <patch>`  Replace the term <from> in
+                                      the given patch with the
+                                      term <to>.
+  `replace.term <from> <to>`          Replace the term <from>
+                                      with <to> in the default
+                                      patch.
 
+```
+```ucm
 .> replace.term 1
 
-  
+  replace.term
+  `replace.term <from> <to> <patch>`  Replace the term <from> in
+                                      the given patch with the
+                                      term <to>.
+  `replace.term <from> <to>`          Replace the term <from>
+                                      with <to> in the default
+                                      patch.
 
+```
+```ucm
 .> replace.term 1 2
 
   ⚠️
@@ -736,53 +985,102 @@ These are treated as failures (for example: a user invokes wrong arguments, less
 
   1 is not a kind of name I understand.
 
+```
+```ucm
 .> link
 
-  
-
-.> links
-
-  
-
-.> unlink
-
-  
-
-.> names
-
-  
-
-.> names 1 2
-
-  
-
-.> dependents
-
-  
-
-.> dependents 1 2
-
-  
-
-.> dependencies
-
-  
-
-.> dependencies 1 2
-
-  
-
-.> run
-
-  
-
-.> run 1 2
-
-  
-
-.> create.author
-
-  
+  link
+  `link metadata defn` creates a link to `metadata` from `defn`.
+  Use `links defn` or `links defn <type>` to view outgoing
+  links, and `unlink metadata defn` to remove a link. The `defn`
+  can be either the name of a term or type, multiple such names,
+  or a range like `1-4` for a range of definitions listed by a
+  prior `find` command.
 
 ```
-load cannot be tested as its output changes per invocation of the trancript
+```ucm
+.> links
+
+  links
+  `links defn`        shows all outgoing links from `defn`.
+  `links defn <type>` shows all links of the given type.
+
+```
+```ucm
+.> unlink
+
+  unlink (or delete.link)
+  `unlink metadata defn` removes a link to `detadata` from
+  `defn`.The `defn` can be either the name of a term or type,
+  multiple such names, or a range like `1-4` for a range of
+  definitions listed by a prior `find` command.
+
+```
+```ucm
+.> names
+
+  names
+  `names foo` shows the hash and all known names for `foo`.
+
+```
+```ucm
+.> names 1 2
+
+  names
+  `names foo` shows the hash and all known names for `foo`.
+
+```
+```ucm
+.> dependents
+
+  dependents
+  List the dependents of the specified definition.
+
+```
+```ucm
+.> dependents 1 2
+
+  dependents
+  List the dependents of the specified definition.
+
+```
+```ucm
+.> dependencies
+
+  dependencies
+  List the dependencies of the specified definition.
+
+```
+```ucm
+.> dependencies 1 2
+
+  dependencies
+  List the dependencies of the specified definition.
+
+```
+```ucm
+.> run
+
+  run
+  `run mymain`  Runs `!mymain`, where `mymain` is searched for
+                in the most recent typechecked file, or in the
+                codebase.
+
+```
+```ucm
+.> run 1 2
+
+  run
+  `run mymain`  Runs `!mymain`, where `mymain` is searched for
+                in the most recent typechecked file, or in the
+                codebase.
+
+```
+```ucm
+.> create.author
+
+  create.author
+  `create.author alicecoder "Alice McGee"` creates `alicecoder`
+  values in `metadata.authors` and `metadata.copyrightHolders`.
+
+```

--- a/unison-src/transcripts/help.output.md
+++ b/unison-src/transcripts/help.output.md
@@ -190,7 +190,349 @@
 
 .> help
 
+  add
+  `add` adds to the codebase all the definitions from the most
+  recently typechecked file.
   
+  add.preview
+  `add.preview` previews additions to the codebase from the most
+  recently typechecked file. This command only displays cached
+  typechecking results. Use `load` to reparse & typecheck the
+  file if the context has changed.
+  
+  alias.many (or copy)
+  `alias.many <relative1> [relative2...] <namespace>` creates
+  aliases `relative1`, `relative2`, ... in the namespace
+  `namespace`.
+  `alias.many foo.foo bar.bar .quux` creates aliases
+  `.quux.foo.foo` and `.quux.bar.bar`.
+  
+  alias.term
+  `alias.term foo bar` introduces `bar` with the same definition
+  as `foo`.
+  
+  alias.type
+  `alias.type Foo Bar` introduces `Bar` with the same definition
+  as `Foo`.
+  
+  back (or popd)
+  `back`  undoes the last `namespace` command.
+  
+  builtins.merge
+  Adds the builtins to `builtins.` in the current namespace
+  (excluding `io` and misc).
+  
+  builtins.mergeio
+  Adds all the builtins to `builtins.` in the current namespace,
+  including `io` and misc.
+  
+  builtins.update
+  Adds all the builtins that are missing from this namespace,
+  and deprecate the ones that don't exist in this version of
+  Unison.
+  
+  copy.patch
+  `copy.patch foo bar` copies the patch `bar` to `foo`.
+  
+  create.author
+  `create.author alicecoder "Alice McGee"` creates `alicecoder`
+  values in `metadata.authors` and `metadata.copyrightHolders`.
+  
+  debug.file
+  View details about the most recent succesfully typechecked
+  file.
+  
+  debug.history
+  Dump codebase history, compatible with
+  bit-booster.com/graph.html
+  
+  debug.numberedArgs
+  Dump the contents of the numbered args state.
+  
+  delete
+  `delete foo` removes the term or type name `foo` from the
+  namespace.
+  
+  delete.namespace
+  `delete.namespace <foo>` deletes the namespace `foo`
+  
+  delete.patch
+  `delete.patch <foo>` deletes the patch `foo`
+  
+  delete.term
+  `delete.term foo` removes the term name `foo` from the
+  namespace.
+  
+  delete.term-replacement
+  delete.term-replacement <patch>` removes any edit of the term
+  `foo` from the patch `patch`, or the default patch if none is
+  specified.
+  
+  delete.type
+  `delete.type foo` removes the type name `foo` from the
+  namespace.
+  
+  delete.type-replacement
+  delete.type-replacement <patch>` removes any edit of the type
+  `foo` from the patch `patch`, or the default patch if none is
+  specified.
+  
+  dependencies
+  List the dependencies of the specified definition.
+  
+  dependents
+  List the dependents of the specified definition.
+  
+  diff.namespace
+  `diff.namespace before after` shows how the namespace `after`
+                                differs from the namespace
+                                `before`
+  
+  display
+  `display foo` prints a rendered version of the term `foo`.
+  
+  display.to
+  `display.to <filename> foo` prints a rendered version of the
+  term `foo` to the given file.
+  
+  docs
+  `docs foo` shows documentation for the definition `foo`.
+  
+  edit
+  `edit foo` prepends the definition of `foo` to the top of the
+  most recently saved file.
+  
+  find
+  `find`          lists all definitions in the current
+                  namespace.
+  `find foo`      lists all definitions with a name similar to
+                  'foo' in the current namespace.
+  `find foo bar`  lists all definitions with a name similar to
+                  'foo' or 'bar' in the current namespace.
+  
+  find.patch (or list.patch, ls.patch)
+  `find.patch`  lists all patches in the current namespace.
+  
+  find.verbose (or list.verbose, ls.verbose)
+  `find.verbose` searches for definitions like `find`, but
+  includes hashes and aliases in the results.
+  
+  fork (or copy.namespace)
+  `fork src dest` creates the namespace `dest` as a copy of
+  `src`.
+  
+  help (or ?)
+  `help` shows general help and `help <cmd>` shows help for one
+  command.
+  
+  help-topics (or help-topic)
+  `help-topics` lists all topics and `help-topics <topic>` shows
+  an explanation of that topic.
+  
+  history
+  `history`                     Shows the history of the current
+                                path.
+  `history .foo`                Shows history of the path .foo.
+  `history #9dndk3kbsk13nbpeu`  Shows the history of the
+                                namespace with the given hash.
+                                The full hash must be provided.
+  
+  link
+  `link metadata defn` creates a link to `metadata` from `defn`.
+  Use `links defn` or `links defn <type>` to view outgoing
+  links, and `unlink metadata defn` to remove a link. The `defn`
+  can be either the name of a term or type, multiple such names,
+  or a range like `1-4` for a range of definitions listed by a
+  prior `find` command.
+  
+  links
+  `links defn`        shows all outgoing links from `defn`.
+  `links defn <type>` shows all links of the given type.
+  
+  list (or ls)
+  `list`       lists definitions and namespaces at the current
+               level of the current namespace.
+  `list foo`   lists the 'foo' namespace.
+  `list .foo`  lists the '.foo' namespace.
+  
+  load
+  `load`                 parses, typechecks, and evaluates the
+                         most recent scratch file.
+  `load <scratch file>`  parses, typechecks, and evaluates the
+                         given scratch file.
+  
+  merge
+  `merge src`      merges `src` namespace into the current namespace
+  `merge src dest` merges `src` namespace into the `dest` namespace
+  
+  merge.preview
+  `merge.preview src`      shows how the current namespace will change after a `merge src`.
+  `merge.preview src dest` shows how `dest` namespace will change after a `merge src dest`.
+  
+  move.namespace (or rename.namespace)
+  `move.namespace foo bar` renames the path `bar` to `foo`.
+  
+  move.patch (or rename.patch)
+  `move.patch foo bar` renames the patch `bar` to `foo`.
+  
+  move.term (or rename.term)
+  `move.term foo bar` renames `foo` to `bar`.
+  
+  move.type (or rename.type)
+  `move.type foo bar` renames `foo` to `bar`.
+  
+  names
+  `names foo` shows the hash and all known names for `foo`.
+  
+  namespace (or cd, j)
+  `namespace foo.bar`   descends into foo.bar from the current
+                        namespace.
+  `namespace .cat.dog`  sets the current namespace to the
+                        abolute namespace .cat.dog.
+  
+  patch
+  `patch` rewrites any definitions that depend on definitions
+  with type-preserving edits to use the updated versions of
+  these dependencies.
+  
+  pull
+  The `pull` command merges a remote namespace into a local
+  namespace.
+  `pull remote local`  merges the remote namespace `remote` into
+                       the local namespace `local`.
+  `pull remote`        merges the remote namespace `remote` into
+                       the current namespace
+  `pull`               merges the remote namespace configured in
+                       `.unisonConfig` with the key `GitUrl.ns`
+                       where `ns` is the current namespace, into
+                       the current namespace
+  where `remote` is a git repository, optionally followed by `:`
+  and an absolute remote path, such as:
+  `https://github.com/org/repo`
+  `https://github.com/org/repo:.some.remote.path`
+  
+  pull-request.create (or pr.create)
+  `pull-request.create base head` will generate a request to
+  merge the remote repo `head` into the remote repo `base`.
+  
+  example: pull-request.create https://github.com/unisonweb/base https://github.com/me/unison:.libs.pr.base
+  
+  pull-request.load (or pr.load)
+  `pull-request.load base head` will load a pull request for
+  merging the remote repo `head` into the remote repo `base`,
+  staging each in the current namespace (so make yourself a
+  clean spot to work first).
+  `pull-request.load base head dest` will load a pull request
+  for merging the remote repo `head` into the remote repo
+  `base`, staging each in `dest`, which must be empty.
+  
+  push
+  The `push` command merges a local namespace into a remote
+  namespace.
+  `push remote local`  merges the contents of the local
+                       namespace `local` into the remote
+                       namespace `remote`.
+  `push remote`        publishes the current namespace into the
+                       remote namespace `remote`
+  `push`               publishes the current namespace into the
+                       remote namespace configured in
+                       `.unisonConfig` with the key `GitUrl.ns`
+                       where `ns` is the current namespace
+  where `remote` is a git repository, optionally followed by `:`
+  and an absolute remote path, such as:
+  `https://github.com/org/repo`
+  `https://github.com/org/repo:.some.remote.path`
+  
+  quit (or exit, :q)
+  Exits the Unison command line interface.
+  
+  reflog
+  `reflog` lists the changes that have affected the root
+  namespace
+  
+  replace.term
+  `replace.term <from> <to> <patch>`  Replace the term <from> in
+                                      the given patch with the
+                                      term <to>.
+  `replace.term <from> <to>`          Replace the term <from>
+                                      with <to> in the default
+                                      patch.
+  
+  replace.type
+  `replace.type <from> <to> <patch>`  Replace the type <from> in
+                                      the given patch with the
+                                      type <to>.
+  `replace.type <from> <to>`          Replace the type <from>
+                                      with <to> in the default
+                                      patch.
+  
+  reset-root
+  `reset-root .foo`                Reset the root namespace
+                                   (along with its history) to
+                                   that of the `.foo` namespace.
+  `reset-root #9dndk3kbsk13nbpeu`  Reset the root namespace
+                                   (along with its history) to
+                                   that of the namespace with
+                                   hash `#9dndk3kbsk13nbpeu`.
+  
+  run
+  `run mymain`  Runs `!mymain`, where `mymain` is searched for
+                in the most recent typechecked file, or in the
+                codebase.
+  
+  test
+  `test` runs unit tests for the current branch.
+  
+  todo
+  `todo`                 lists the refactor work remaining in
+                         the default patch for the current
+                         namespace.
+  `todo <patch>`         lists the refactor work remaining in
+                         the given patch in the current
+                         namespace.
+  `todo <patch> [path]`  lists the refactor work remaining in
+                         the given patch in given namespace.
+  
+  undo
+  `undo` reverts the most recent change to the codebase.
+  
+  unlink (or delete.link)
+  `unlink metadata defn` removes a link to `detadata` from
+  `defn`.The `defn` can be either the name of a term or type,
+  multiple such names, or a range like `1-4` for a range of
+  definitions listed by a prior `find` command.
+  
+  update
+  `update` works like `add`, except that if a definition in the
+  file has the same name as an existing definition, the name
+  gets updated to point to the new definition. If the old
+  definition has any dependents, `update` will add those
+  dependents to a refactoring session, specified by an optional
+  patch.
+  `update`                  adds all definitions in the .u file,
+                            noting replacements in the default
+                            patch for the current namespace.
+  `update <patch>`          adds all definitions in the .u file,
+                            noting replacements in the specified
+                            patch.
+  `update <patch> foo bar`  adds `foo`, `bar`, and their
+                            dependents from the .u file, noting
+                            any replacements into the specified
+                            patch.
+  
+  update.preview
+  `update.preview` previews updates to the codebase from the
+  most recently typechecked file. This command only displays
+  cached typechecking results. Use `load` to reparse & typecheck
+  the file if the context has changed.
+  
+  view
+  `view foo` prints the definition of `foo`.
+  
+  view.patch
+  `view.patch`          Lists all the edits in the default
+                        patch.
+  `view.patch <patch>`  Lists all the edits in the given patch.
 
 .> help push
 
@@ -202,18 +544,6 @@
 These are treated as failures (for example: a user invokes wrong arguments, less or more)
 
 ```ucm
-.> load
-
-  😶
-  
-  There's nothing for me to add right now.
-  
-  Hint: I'm currently watching for definitions in .u files under
-        the ~/unisonweb/unison/transcript-2e60832c90c01787
-        directory. Make sure you've updated something there
-        before using the `add` or `update` commands, or use
-        `load` to load a file explicitly.
-
 .> load 1 2 3
 
   
@@ -455,3 +785,4 @@ These are treated as failures (for example: a user invokes wrong arguments, less
   
 
 ```
+load cannot be tested as its output changes per invocation of the trancript

--- a/unison-src/transcripts/help.output.md
+++ b/unison-src/transcripts/help.output.md
@@ -188,4 +188,270 @@
   temporarily (like `exports.blah.foo`) and then use `move.*` or
   `merge` commands to move stuff around afterwards.
 
+.> help
+
+  
+
+.> help push
+
+  
+
+```
+### Tests output 'help your-command' due to broken invocation of a command
+
+These are treated as failures (for example: a user invokes wrong arguments, less or more)
+
+```ucm
+.> load
+
+  😶
+  
+  There's nothing for me to add right now.
+  
+  Hint: I'm currently watching for definitions in .u files under
+        the ~/unisonweb/unison/transcript-2e60832c90c01787
+        directory. Make sure you've updated something there
+        before using the `add` or `update` commands, or use
+        `load` to load a file explicitly.
+
+.> load 1 2 3
+
+  
+
+.> display
+
+  
+
+.> display 1 2 3
+
+  
+
+.> display.to
+
+  
+
+.> display.to 1 2 3
+
+  
+
+.> docs
+
+  
+
+.> docs 1 2
+
+  
+
+.> list
+
+  nothing to show
+
+.> list 1 2
+
+  
+
+.> alias.many
+
+  
+
+.> cd
+
+  
+
+.> cd 1 2 3
+
+  
+
+.> back 1
+
+  
+
+.> delete.namespace 1 2 3
+
+  
+
+.> delete.patch 1 2
+
+  
+
+.> copy.patch 1 2 3
+
+  
+
+.> rename.patch 1 2 3
+
+  
+
+.> rename.namespace 1 2 3
+
+  
+
+.> history 1 2 3
+
+  
+
+.> fork
+
+  
+
+.> fork 1
+
+  
+
+.> fork 1 2 3
+
+  
+
+.> reset-root
+
+  
+
+.> reset-root 1 2
+
+  
+
+.> pull
+
+  ❗️
+  
+  I don't know where to pull from! Add a line like `GitUrl. the
+  current namespace = <some-git-url>' to .unisonConfig. Type
+  `help pull ` for more information.
+
+.> pull 1 2 3
+
+  
+
+.> pull-request.create
+
+  
+
+.> pull-request.create 1 2 3
+
+  
+
+.> pull-request.load
+
+  
+
+.> pull-request.load 1
+
+  
+
+.> pull-request.load 1 2 3 4
+
+  
+
+.> merge
+
+  
+
+.> merge 1 2 3
+
+  
+
+.> diff.namespace
+
+  
+
+.> diff.namespace 1
+
+  
+
+.> diff.namespace 1 2 3
+
+  
+
+.> merge.preview
+
+  
+
+.> merge.preview 1 2 3
+
+  
+
+.> replace.type
+
+  
+
+.> replace.type 1 
+
+  
+
+.> replace.type 1 2
+
+  ⚠️
+  
+  The following names were not found in the codebase. Check your spelling.
+    1
+    2
+
+  1 is not a kind of name I understand.
+
+.> replace.term
+
+  
+
+.> replace.term 1
+
+  
+
+.> replace.term 1 2
+
+  ⚠️
+  
+  The following names were not found in the codebase. Check your spelling.
+    1
+    2
+
+  1 is not a kind of name I understand.
+
+.> link
+
+  
+
+.> links
+
+  
+
+.> unlink
+
+  
+
+.> names
+
+  
+
+.> names 1 2
+
+  
+
+.> dependents
+
+  
+
+.> dependents 1 2
+
+  
+
+.> dependencies
+
+  
+
+.> dependencies 1 2
+
+  
+
+.> run
+
+  
+
+.> run 1 2
+
+  
+
+.> create.author
+
+  
+
 ```

--- a/unison-src/transcripts/help.output.md
+++ b/unison-src/transcripts/help.output.md
@@ -797,6 +797,27 @@ These are treated as failures (for example: a user invokes wrong arguments, less
 
 ```
 ```ucm
+.> push 1 2 3
+
+  push
+  The `push` command merges a local namespace into a remote
+  namespace.
+  `push remote local`  merges the contents of the local
+                       namespace `local` into the remote
+                       namespace `remote`.
+  `push remote`        publishes the current namespace into the
+                       remote namespace `remote`
+  `push`               publishes the current namespace into the
+                       remote namespace configured in
+                       `.unisonConfig` with the key `GitUrl.ns`
+                       where `ns` is the current namespace
+  where `remote` is a git repository, optionally followed by `:`
+  and an absolute remote path, such as:
+  `https://github.com/org/repo`
+  `https://github.com/org/repo:.some.remote.path`
+
+```
+```ucm
 .> pull-request.create
 
   pull-request.create (or pr.create)


### PR DESCRIPTION
## Overview

The `HelpI` changes targeting the branch that has the `HelpTopicsI` changes, for ease of reviewing and communications.

Before: help is printed directly to the terminal
After: 
* `help` you ask for is handled and is a success. 
* `help` you don't ask for (invalid usage) is presented and is handled and is a failure.

## Implementation notes

`HelpI (Maybe PatternInput) _` causes a cycle in imports due to:
 `parse       :: [String] -> Either (P.Pretty CT.ColorText) Input`

The way the code is structured currently (Input/InputPattern/InputPatterns), I cannot see a straightforward way to move `parse` out of the cycle. 
(Guidance needed if this ^^ plan of action is required)

I have instead chosen to wrap the name of the command instead of the `PatternInput`
`HelpI (Maybe String) Bool`  passes around the name of the command, and whether it should be treated as a success or failure during the generation of the output.

## Interesting/controversial decisions

* `String vs PatternInput + restructure`
* The boolean for status: is it too noisy? Should there be two constructors instead?

## Test coverage

* help
* help command
* every invalid invocation produced by reading the code (to the best of my ability the list is complete)

## Loose ends

N/A